### PR TITLE
:export functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,15 @@ A block of code in pLam is a line, and possible lines (commands) are the followi
 - example: `:import std`
 - restriction: `<string>.plam` has to be inside `import/` directory within the pLam project directory
 
+<a name="exp"/>
+
+### Export
+
+- syntax `:export <string<`
+- semantics: put all the expressions in the list of environment variables into the file `import/<string>.plam`
+- example: `:export test`
+- restriction: `<string>.plam cannot already exist
+
 <a name="comm"/>
 
 ### Comment

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ A block of code in pLam is a line, and possible lines (commands) are the followi
 - syntax `:export <string<`
 - semantics: put all the expressions in the list of environment variables into the file `import/<string>.plam`
 - example: `:export test`
-- restriction: `<string>.plam cannot already exist
+- restriction: `<string>.plam` cannot already exist
 
 <a name="comm"/>
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -100,7 +100,7 @@ execute line env =
                     if not fileExists
                         then do
                             outFile <- liftIO $ openFile (importPath ++ f ++ ".plam") WriteMode
-                            liftIO $ mapM_ (saveGlobal outFile) env
+                            liftIO $ mapM_ (saveGlobal outFile) (reverse env)
                             liftIO $ hClose outFile
                             outputStrLn("--- exported to " ++ f ++ " sucessful.")
                         else do

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -161,6 +161,13 @@ execJustProg (line:ls) env =
                         Right exp -> do
                             autoProgReduce env exp 0
                             execJustProg ls env'
+                Review r -> do
+                    case r of
+                       "all" -> do
+                           putStrLn " ENVIRONMENT:"
+                           mapM_ printGlobal env
+                       otherwise -> putStrLn ("--- definition of " ++ show r ++ ": " ++ reviewVariable env r)
+                    execJustProg ls env
                 Print s -> do
                     putStrLn s
                     execJustProg ls env

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -6,7 +6,7 @@ import Reducer
 import Helper
 
 import Control.Monad.State
-import System.IO (hFlush, stdout)
+import System.IO (hFlush, stdout, hPutStrLn, hClose, openFile, IOMode(WriteMode))
 import Debug.Trace
 import System.Exit
 import System.Console.Haskeline
@@ -93,7 +93,13 @@ execute line env =
                 Import f -> do
                     content <- liftIO $ readFile (importPath ++ f ++ ".plam")
                     let exprs = lines content
-                    execAll exprs env                  
+                    execAll exprs env
+                Export f -> do
+                    outFile <- liftIO $ openFile (importPath ++ f ++ ".plam") WriteMode
+                    liftIO $ mapM_ (saveGlobal outFile) env
+                    liftIO $ hClose outFile
+                    outputStrLn("--- exported to " ++ f ++ " sucessful.")
+                    return env
                 Review r -> do
                     case r of
                        "all" -> do

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -11,6 +11,7 @@ import Debug.Trace
 import System.Exit
 import System.Console.Haskeline
 import System.Environment
+import System.Directory (doesFileExist)
 
 
 version = "2.0.0"
@@ -95,10 +96,15 @@ execute line env =
                     let exprs = lines content
                     execAll exprs env
                 Export f -> do
-                    outFile <- liftIO $ openFile (importPath ++ f ++ ".plam") WriteMode
-                    liftIO $ mapM_ (saveGlobal outFile) env
-                    liftIO $ hClose outFile
-                    outputStrLn("--- exported to " ++ f ++ " sucessful.")
+                    fileExists <- liftIO $ doesFileExist (importPath ++ f ++ ".plam")
+                    if not fileExists
+                        then do
+                            outFile <- liftIO $ openFile (importPath ++ f ++ ".plam") WriteMode
+                            liftIO $ mapM_ (saveGlobal outFile) env
+                            liftIO $ hClose outFile
+                            outputStrLn("--- exported to " ++ f ++ " sucessful.")
+                        else do
+                            outputStrLn("--- export failed : " ++ f ++ " already exists")
                     return env
                 Review r -> do
                     case r of

--- a/pLam.cabal
+++ b/pLam.cabal
@@ -32,6 +32,7 @@ executable plam
                      , mtl
                      , containers
                      , haskeline
+                     , directory
   default-language:    Haskell2010
 
 source-repository head

--- a/src/Helper.hs
+++ b/src/Helper.hs
@@ -5,7 +5,7 @@ import Reducer
 import Parser
 
 import Control.Monad.State
-import System.IO (hFlush, stdout)
+import System.IO (hFlush, stdout, Handle, hPutStrLn)
 import Debug.Trace
 import System.Console.Haskeline
 
@@ -13,6 +13,16 @@ import System.Console.Haskeline
 -------------------------------------------------------------------------------------
 showGlobal :: (String, Expression) -> InputT IO ()
 showGlobal (n, e) = outputStrLn ("--- " ++ show n ++ " = " ++ show e)
+
+removeLambda :: String -> String
+removeLambda target =
+    let
+        repl 'λ' = '\\'
+        repl  c  =  c
+    in map repl target
+    
+saveGlobal :: Handle -> (String, Expression) -> IO ()
+saveGlobal h (n, e) = hPutStrLn h (n ++ " = " ++ (removeLambda (show e)))
 
 convertToName :: Environment -> Expression -> String
 convertToName [] exp = findNumeral exp

--- a/src/Helper.hs
+++ b/src/Helper.hs
@@ -14,6 +14,9 @@ import System.Console.Haskeline
 showGlobal :: (String, Expression) -> InputT IO ()
 showGlobal (n, e) = outputStrLn ("--- " ++ show n ++ " = " ++ show e)
 
+printGlobal :: (String, Expression) -> IO ()
+printGlobal (n, e) = putStrLn ("--- " ++ show n ++ " = " ++ show e)
+
 removeLambda :: String -> String
 removeLambda target =
     let

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -164,6 +164,13 @@ parseImport = do
     f <- filename
     return $ Import f
 
+parseExport :: Parser Command
+parseExport = do
+    reserved ":export"
+    spaces
+    f <- filename
+    return $ Export f
+
 parseReview :: Parser Command
 parseReview = do
     reserved ":review"
@@ -200,12 +207,14 @@ parseLine :: Parser Command
 parseLine =  try parseDefine
          <|> parseShowDetailed
          <|> parseImport
+         <|> parseExport
          <|> parseReview
          <|> parseRun
          <|> parsePrint
          <|> parseComment
          <|> parseShow
          <|> parseEmptyLine
+         
 -------------------------------------------------------------------------------------
 
 -------------------------------------------------------------------------------------

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -43,6 +43,7 @@ data Command = Define String Expression
              | Show Expression
              | ShowDetailed Expression
              | Import String
+             | Export String
              | Review String
              | Comment String
              | Run String


### PR DESCRIPTION
Added ability to :export the environment variables into a .plam file with similar syntax to the :import command.

The export goes into the import directory, and will check to make sure it is not overwriting any existing files.

I also added the ability to use :review <symbol> and :review all in .plam files. This way the user can create a demonstration file that outputs the current definition of various symbols, or the whole environment as needed.

To test the functionality, I opened each of the standard libraries and exported them into a second copy. I then diff checked the output of ":review all" when called against importing both the original standard library, and the newly exported version. The diff checks all came back with 0 differences.